### PR TITLE
updated masterdetail page to host a RoutedViewModel

### DIFF
--- a/src/ReactiveMasterDetail/AppBootstrapper.cs
+++ b/src/ReactiveMasterDetail/AppBootstrapper.cs
@@ -16,10 +16,10 @@ namespace ReactiveMasterDetail
             RegisterScreen();
             RegisterViews();
             RegisterViewModels();
-            this.Router.NavigateAndReset.Execute(new MasterViewModel()).Subscribe();
+            this.Router.NavigateAndReset.Execute(Locator.Current.GetService<ThingOneViewModel>()).Subscribe();
         }
 
-        public Page CreateMainPage() => new RoutedViewHost();
+        public Page CreateMainPage() => new MasterPage(new MasterViewModel());
 
         private void RegisterScreen()
         {
@@ -34,7 +34,6 @@ namespace ReactiveMasterDetail
 
         private void RegisterViews()
         {
-            Locator.CurrentMutable.Register(() => new MasterPage(), typeof(IViewFor<MasterViewModel>));
             Locator.CurrentMutable.Register(() => new ThingOnePage(), typeof(IViewFor<ThingOneViewModel>));
             Locator.CurrentMutable.Register(() => new ThingTwoPage(), typeof(IViewFor<ThingTwoViewModel>));
         }

--- a/src/ReactiveMasterDetail/Master/MasterPage.xaml
+++ b/src/ReactiveMasterDetail/Master/MasterPage.xaml
@@ -36,10 +36,7 @@
         </ContentPage>
     </MasterDetailPage.Master>
     <MasterDetailPage.Detail>
-        <NavigationPage>
-            <x:Arguments>
-                <local:ThingOnePage />
-            </x:Arguments>
-        </NavigationPage>
+        <reactiveui:RoutedViewHost>
+        </reactiveui:RoutedViewHost>
     </MasterDetailPage.Detail>
 </reactiveui:ReactiveMasterDetailPage>

--- a/src/ReactiveMasterDetail/Master/MasterPage.xaml.cs
+++ b/src/ReactiveMasterDetail/Master/MasterPage.xaml.cs
@@ -11,9 +11,10 @@ namespace ReactiveMasterDetail
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class MasterPage : ReactiveMasterDetailPage<MasterViewModel>
     {
-        public MasterPage()
+        public MasterPage(MasterViewModel viewModel)
         {
             InitializeComponent();
+            ViewModel = viewModel;
         }
     }
 }

--- a/src/ReactiveMasterDetail/Master/MasterViewModel.cs
+++ b/src/ReactiveMasterDetail/Master/MasterViewModel.cs
@@ -40,7 +40,8 @@ namespace ReactiveMasterDetail
             return (IRoutableViewModel)Locator.Current.GetService(item.TargetType);
         }
 
-        private IObservable<Unit> ExecuteItemSelectedCommand(MasterPageItem item) => HostScreen.Router.Navigate.Execute(GetViewModel(item)).ToSignal();
+        private IObservable<Unit> ExecuteItemSelectedCommand(MasterPageItem item) 
+            => HostScreen.Router.NavigateAndReset.Execute(GetViewModel(item)).ToSignal();
 
         private void SetupReactiveObservables()
         {

--- a/src/ReactiveMasterDetail/ThingOne/ThingOnePage.xaml
+++ b/src/ReactiveMasterDetail/ThingOne/ThingOnePage.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:reactiveui="clr-namespace:ReactiveUI.XamForms;assembly=ReactiveUI.XamForms"
              xmlns:local="clr-namespace:ReactiveMasterDetail;assembly=ReactiveMasterDetail"
+             Title="Thing One"
              x:Class="ReactiveMasterDetail.ThingOnePage">
     <ContentPage.Content>
         <StackLayout>

--- a/src/ReactiveMasterDetail/ThingTwo/ThingTwoPage.xaml
+++ b/src/ReactiveMasterDetail/ThingTwo/ThingTwoPage.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:reactiveui="clr-namespace:ReactiveUI.XamForms;assembly=ReactiveUI.XamForms"
              xmlns:local="clr-namespace:ReactiveMasterDetail;assembly=ReactiveMasterDetail"
+             Title="Thing Two"
              x:Class="ReactiveMasterDetail.ThingTwoPage">
     <ContentPage.Content>
         <StackLayout>


### PR DESCRIPTION
Made a few changes to fix the issues we discussed earlier

1. Double tool bar (since you have master detail page inside navigation page, i see two tool bars)
[AK] This is fixed, since we host the MasterDetail page as the MainPage. The RoutedViewModel is then hosted within the "Detail" section of the masterdetail page.

2. After opening a detail page, the title does not show up in the tool bar. (This is perhaps a bug? The title shows up fine with regular MasterDetailPage)
[AK]  This is still an issue. When i navigate to ThingOne/ThingTwo the titles are not shows in the bar.

3. When opening a detail page, it should not be put on the stack, instead it should replace the current detail page (with hamburger menu still visible, instead of back button).
[AK] Fixed this, by doing NavigateAndReset in the ItemTappedCommand

However, now there is an additional issue:
On tapping an item in the Master page, the detail page navigates correctly to the given page. However, the slide-out pane is not hidden at this time. We can do this by setting IsPresent=False in the view, but this needs additional event handling, and breaks the View-ViewModel behavior. Ideally, we should be able to do this from the ViewModel.
